### PR TITLE
fix: add prevent modifier when hitting "enter" in dropdown

### DIFF
--- a/src/index.vue
+++ b/src/index.vue
@@ -7,7 +7,7 @@
     @focus="focus"
     @blur="e => (searchable ? false : blur(e))"
     v-bind="dataAttrs"
-    @keypress.enter.exact="
+    @keypress.enter.prevent.exact="
       () => highlightedOriginalIndex !== null && addOrRemoveOption($event, optionsWithInfo[highlightedOriginalIndex])
     "
     @keydown.down.prevent.exact="pointerForward"


### PR DESCRIPTION
I have a form that uses `@submit` on entire form and every time I select an option from the dropdown the form gets submitted.